### PR TITLE
ci: skip Qodana for dependabot PRs

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   qodana:
     runs-on: ubuntu-latest
+    # Skip for dependabot PRs - they can't access QODANA_TOKEN secret
+    if: github.actor != 'dependabot[bot]'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
Dependabot PRs cannot access repository secrets (like QODANA_TOKEN), causing Qodana to fail.

## Change
Added condition to skip the Qodana job when the actor is dependabot[bot].

## Impact
After merging, dependabot PRs will no longer fail on the Qodana check.