### PR TITLE
[CLEANUP] Forge Inventory Centralization

### DIFF
--- a/DEBT.md
+++ b/DEBT.md
@@ -64,7 +64,7 @@
 | 2026-01-06 | `src/features/oracle/OracleChat.tsx` | Improved `context` prop from `any` to `Record<string, unknown>`. @ts-ignore and `as any` casts remain due to @ai-sdk/react type limitations. | @cleanup | ⚠️ Deferred (Lib) |
 | 2026-01-06 | `package.json` | PR #31 (Dependencies) deferred (Zod 4, ESLint 9) | @infrastructure | ⚠️ Deferred |
 | 2026-01-06 | `src/services/analytics/GrowthMetricsService.ts` | `getSocialEngagement` is a placeholder. Requires 'Friendship' model implementation. | @architect | ✅ Resolved (Verified, added tests) |
-| 2026-01-06 | `src/features/game/TheForge.tsx` | Mock inventory state and 'optimistic update' logic needs proper hook/server-sync. | @coder | ⚠️ Open |
+| 2026-01-06 | `src/features/game/TheForge.tsx` | Mock inventory state now synchronized via `getInventoryAction`. DB schema update still pending. | @coder | ✅ Resolved |
 | 2026-01-06 | `src/actions/economy/forge.ts` | `getInventory` uses mock data. DB schema update needed for stackable resources. | @architect | ⚠️ Deferred (Schema) |
 | 2026-01-06 | `src/features/game/hooks/useSkillEffects.ts` | Keystone selection logic only supports first keystone. Needs multi-keystone/switching support. | @game-designer | ✅ Resolved |
 | 2026-01-06 | `src/actions/guild/raids.ts` | `startRaidAction` missing admin permission check (`// TODO: Verify user is admin`). | @security | ✅ Resolved |

--- a/src/actions/economy/forge.ts
+++ b/src/actions/economy/forge.ts
@@ -28,6 +28,29 @@ async function getInventory(userId: string): Promise<UserInventory> {
   };
 }
 
+export async function getInventoryAction(): Promise<{
+  success: boolean;
+  data?: UserInventory;
+  message?: string;
+}> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return { success: false, message: "Unauthorized" };
+    }
+
+    const inventory = await getInventory(user.id);
+    return { success: true, data: inventory };
+  } catch (error) {
+    console.error("Failed to fetch inventory:", error);
+    return { success: false, message: "Failed to load inventory" };
+  }
+}
+
 export async function craftItem(
   recipeId: string,
 ): Promise<{ success: boolean; message: string; inventory?: UserInventory }> {

--- a/src/features/game/TheForge.tsx
+++ b/src/features/game/TheForge.tsx
@@ -6,7 +6,7 @@ import ForgeButton from "@/components/ui/ForgeButton";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { ITEMS, RECIPES } from "@/data/gameData";
 import { UserInventory, CraftingRecipe } from "@/types/game";
-import { craftItem } from "@/actions/economy/forge";
+import { craftItem, getInventoryAction } from "@/actions/economy/forge";
 import { toast } from "@/components/ui/GameToast";
 import { Hammer, Anvil, Coins } from "lucide-react";
 
@@ -21,18 +21,17 @@ const TheForge: React.FC<TheForgeProps> = ({ onClose }) => {
   // const [_loading, _setLoading] = useState(false);
   const [craftingId, setCraftingId] = useState<string | null>(null);
 
-  // Initial Mock Load (Replace with server action fetch later if needed)
+  // Initial Load
   useEffect(() => {
-    // Simulating data fetch
-    const mockInventory: UserInventory = {
-      userId: "current-user",
-      gold: 500,
-      items: [
-        { itemId: "item_iron_ore", count: 10 },
-        { itemId: "item_flux", count: 5 },
-      ],
-    };
-    setInventory(mockInventory);
+    async function load() {
+      const result = await getInventoryAction();
+      if (result.success && result.data) {
+        setInventory(result.data);
+      } else {
+        toast.error(result.message || "Failed to access the Armory");
+      }
+    }
+    load();
   }, []);
 
   const handleCraft = async (recipe: CraftingRecipe) => {


### PR DESCRIPTION
### Summary
Addresses technical debt by centralizing inventory fetching logic.

### Changes
- Exported \getInventoryAction\ from \src/actions/economy/forge.ts\
- Updated \TheForge.tsx\ to consume server action instead of local mock state
- Removed duplicate mock data

### Verification
- \
pm run lint\ passed
- \
pm run check-types\ passed